### PR TITLE
fix: Improve performance of the UTF-8 string comparison logic

### DIFF
--- a/dev/src/order.ts
+++ b/dev/src/order.ts
@@ -281,8 +281,8 @@ export function compareUtf8Strings(left: string, right: string): number {
       return isSurrogate(leftChar) === isSurrogate(rightChar)
         ? primitiveComparator(leftChar, rightChar)
         : isSurrogate(leftChar)
-        ? 1
-        : -1;
+          ? 1
+          : -1;
     }
   }
 


### PR DESCRIPTION
The real PR is: https://github.com/googleapis/nodejs-firestore/pull/2380

The semantics of this logic were originally fixed by #2275, but this fix caused a material performance degradation, which was then improved by #2299 The performance was, however, still suboptimal, and this PR further improves the speed back to close to its original speed and, serendipitously, simplifies the algorithm too.

This commit is a port of https://github.com/firebase/firebase-js-sdk/pull/9143